### PR TITLE
Bridge ATP requires_proxy to Zyte Smart Proxy

### DIFF
--- a/locations/middlewares/smartproxy_bridge.py
+++ b/locations/middlewares/smartproxy_bridge.py
@@ -1,0 +1,10 @@
+from scrapy_zyte_smartproxy import ZyteSmartProxyMiddleware
+
+
+class SmartProxyBridgeMiddleware(ZyteSmartProxyMiddleware):
+    def is_enabled(self, spider):
+        """
+        Allows Zyte Smart Proxy to be tied to AllThePlace's proxy configuration class member
+        """
+        requires_proxy = getattr(spider, "requires_proxy", False)
+        return requires_proxy or isinstance(requires_proxy, str) or super().is_enabled(spider)

--- a/locations/settings.py
+++ b/locations/settings.py
@@ -71,7 +71,7 @@ TELNETCONSOLE_ENABLED = False
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
     "locations.middlewares.cdnstats.CDNStatsMiddleware": 500,
-    "scrapy_zyte_smartproxy.ZyteSmartProxyMiddleware": 610,
+    "locations.middlewares.smartproxy_bridge.SmartProxyBridgeMiddleware": 610,
 }
 
 # Enable or disable extensions


### PR DESCRIPTION
ATP have this field `requires_proxy`, but it's unimplemented. We can use it.