### PR TITLE
fix: Don't log crawling speed

### DIFF
--- a/locations/settings.py
+++ b/locations/settings.py
@@ -83,7 +83,6 @@ DOWNLOADER_MIDDLEWARES = {
 EXTENSIONS = {
     "locations.extensions.google_auth.GoogleAuthExtension": 10,
     "locations.extensions.stackdriver_logger.StackdriverLoggerExtension": 100,
-    "locations.extensions.log_stats.LogStatsExtension": 101,
 }
 
 # Configure item pipelines


### PR DESCRIPTION
This just floods the logs with lines that nobody is looking at live
<img width="948" alt="image" src="https://github.com/huq-industries/atp/assets/7499526/8540c4f6-1198-45aa-881a-81638e1846c3">
